### PR TITLE
Fix link to LICENSE.md in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ go get -d github.com/adamryman/kit
 
 ## (UN)-LICENCE
 
-All software is released into the public domain. See [`LICENCE.md`](./LICENCE.md)
+All software is released into the public domain. See [`LICENSE.md`](./LICENSE.md)


### PR DESCRIPTION
The link to LICENSE.md was originally LICENCE.md; this commit correctly links to LICENSE.md.